### PR TITLE
Add demo client for development testing

### DIFF
--- a/DemoClient/App.config
+++ b/DemoClient/App.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+    <appSettings>
+
+        <!--  BitcoinLib settings start -->
+
+        <!-- Shared RPC settings start -->
+        <add key="RpcRequestTimeoutInSeconds" value="60" />
+        <!-- Shared RPC settings end -->
+
+        <!-- Bitcoin settings start -->
+        <add key="Tezos_Node_DaemonUrl" value="http://0.0.0.0:0" />
+        <add key="Tezos_Node_DaemonUrl_Testnet" value="http://0.0.0.0:0" />
+
+    </appSettings>
+</configuration>

--- a/DemoClient/DemoClient.csproj
+++ b/DemoClient/DemoClient.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Netezos.Rpc\Netezos.Rpc.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DemoClient/Program.cs
+++ b/DemoClient/Program.cs
@@ -1,0 +1,30 @@
+using Netezos.Rpc;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Configuration;
+
+namespace ConsoleClient
+{
+    internal sealed class Program
+    {
+        // For e.g. the public Carthage test net, the test net parameter is false. It is only
+        // true for local sandboxed instances of Tezos blockchains
+        private static bool useTestNet = false;
+        private static readonly TezosRpc Rpc = new TezosRpc(
+            ConfigurationManager.AppSettings["Tezos_Node_DaemonUrl_Testnet"],
+            useTestNet ? Chain.Test : Chain.Main);
+
+        private static void Main()
+        {
+            try
+            {
+                string headBlockHash = Rpc.Blocks.Head.Hash.GetAsync().Result.Value<string>();
+                Console.WriteLine($"Head hash is: {headBlockHash}");
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine("[Failed]\n\nPlease check your configuration and make sure that the daemon is up and running and that it is synchronized. \n\nException: " + exception);
+            }
+        }
+    }
+}

--- a/Netezos.sln
+++ b/Netezos.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Netezos.Forge", "Netezos.Fo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Netezos.Forge.Tests", "Netezos.Forge.Tests\Netezos.Forge.Tests.csproj", "{3E97D8B6-A811-48D8-B6AF-F60B22230350}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoClient", "DemoClient\DemoClient.csproj", "{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{3E97D8B6-A811-48D8-B6AF-F60B22230350}.Release|x64.Build.0 = Release|Any CPU
 		{3E97D8B6-A811-48D8-B6AF-F60B22230350}.Release|x86.ActiveCfg = Release|Any CPU
 		{3E97D8B6-A811-48D8-B6AF-F60B22230350}.Release|x86.Build.0 = Release|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Debug|x64.Build.0 = Debug|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Debug|x86.Build.0 = Debug|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Release|x64.ActiveCfg = Release|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Release|x64.Build.0 = Release|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Release|x86.ActiveCfg = Release|Any CPU
+		{F9D9DC77-1E0E-41B6-8339-6236A24BF0FA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This setup is inspired by the setup in Cryptean's bitcoinlib[0]. The
developer should enter the IP and port address of their node into the
App.config file to test the connection/implementation. This democlient
is so far just a scaffold. More RPC invocations should be added.

[0]: https://github.com/cryptean/bitcoinlib

This addresses #3 