### PR TITLE
Add mocking capabilities to TezosRpc

### DIFF
--- a/Netezos.Rpc/Base/RpcClient.cs
+++ b/Netezos.Rpc/Base/RpcClient.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Netezos.Rpc
 {
-    class RpcClient : IDisposable
+    public class RpcClient : IDisposable
     {
         public Uri BaseAddress { get; }
         public TimeSpan RequestTimeout { get; }
@@ -53,6 +53,12 @@ namespace Netezos.Rpc
             RequestTimeout = TimeSpan.FromSeconds(timeoutSec);
         }
 
+        public RpcClient(HttpClient httpClient)
+        {
+            _HttpClient = httpClient;
+            _Expiration = DateTime.MaxValue;
+        }
+
         public async Task<JToken> GetJson(string path)
         {
             using (var stream = await HttpClient.GetStreamAsync(path))
@@ -73,7 +79,7 @@ namespace Netezos.Rpc
                 return serializer.Deserialize<T>(jsonReader);
             }
         }
-                
+
         public async Task<JToken> PostJson(string path, string content)
         {
             var response = await HttpClient.PostAsync(path, new JsonContent(content));
@@ -85,8 +91,8 @@ namespace Netezos.Rpc
             {
                 return JToken.ReadFrom(jsonReader);
             }
-        }  
-        
+        }
+
         public async Task<T> PostJson<T>(string path, string content)
         {
             var response = await HttpClient.PostAsync(path, new JsonContent(content));

--- a/Netezos.Rpc/TezosRpc.cs
+++ b/Netezos.Rpc/TezosRpc.cs
@@ -14,7 +14,7 @@ namespace Netezos.Rpc
         /// Gets the query to the blocks
         /// </summary>
         public BlocksQuery Blocks { get; }
-        
+
         /// <summary>
         /// Gets the query to the injection
         /// </summary>
@@ -46,6 +46,21 @@ namespace Netezos.Rpc
         public TezosRpc(string uri, int timeout, Chain chain = Rpc.Chain.Main)
         {
             Client = new RpcClient(uri, timeout);
+            Chain = chain.ToString().ToLower();
+
+            Blocks = new BlocksQuery(Client, $"chains/{Chain}/blocks/");
+            Inject = new InjectionQuery(Client, $"injection/");
+        }
+
+        /// <summary>
+        /// Creates the instance of TezosRpc where the caller injects
+        /// the RpcClient instance.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="chain"></param>
+        public TezosRpc(RpcClient client, Chain chain = Rpc.Chain.Main)
+        {
+            Client = client;
             Chain = chain.ToString().ToLower();
 
             Blocks = new BlocksQuery(Client, $"chains/{Chain}/blocks/");


### PR DESCRIPTION
This is done by adding new constructors which allow the injection of a
HTTPClient which can be mocked using standard methods in .NET.

This solution has not yet been tested.

This closes #9 