### PR TITLE
Make TezosRpc mockable by injecting HttpMessageHandler

### DIFF
--- a/Netezos.Forge/Remote/RpcForge.cs
+++ b/Netezos.Forge/Remote/RpcForge.cs
@@ -14,8 +14,14 @@ namespace Netezos.Forge
     {
         readonly TezosRpc Rpc;
 
+        [Obsolete("Use RpcForge(Uri, TimeSpan, Chain) instead.")]
         public RpcForge(string uri, int timeout = 30_000, Chain chain = Chain.Main)
             => Rpc = new TezosRpc(uri, timeout, chain);
+
+        public RpcForge(Uri baseUri, TimeSpan requestTimeout, Chain chain)
+        {
+            Rpc = new TezosRpc(baseUri, requestTimeout, chain);
+        }
 
         public void Dispose() => Rpc.Dispose();
 

--- a/Netezos.Rpc.Tests/TestBlocks.cs
+++ b/Netezos.Rpc.Tests/TestBlocks.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -9,7 +10,7 @@ namespace Netezos.Rpc.Tests
 
         public TestBlocks()
         {
-            Rpc = new TezosRpc("https://mainnet-tezos.giganode.io/");
+            Rpc = new TezosRpc(new Uri("https://mainnet-tezos.giganode.io/"));
         }
 
         [Fact]


### PR DESCRIPTION
This closes #9 and closes #11.

Following the discussion of #11, this PR injects HttpMessageHandler in through
TezosRpc and RpcClient. It adds ctors that use `Uri` and `TimeSpan` instead of
`string` and `int` and marks existing ctors as obsolete.

Constants like "2 hours", "10 seconds" and "main" are exported to the top.

---

This was made in collaboration with @Sword-Smith.

Please let me know if something needs to be fixed for this PR to be accepted.