### PR TITLE
Make PostAsync() overrideable

### DIFF
--- a/Netezos.Rpc/Base/RpcPost.cs
+++ b/Netezos.Rpc/Base/RpcPost.cs
@@ -17,14 +17,14 @@ namespace Netezos.Rpc
         /// </summary>
         /// <param name="content">Json content to send</param>
         /// <returns></returns>
-        public Task<JToken> PostAsync(string content) => Client.PostJson(Query, content);
+        public virtual Task<JToken> PostAsync(string content) => Client.PostJson(Query, content);
 
         /// <summary>
         /// Send a POST request with specified json object content and returns the json object
         /// </summary>
         /// <param name="content">Object to send</param>
         /// <returns></returns>
-        public Task<JToken> PostAsync(object content) => Client.PostJson(Query, content.ToJson());
+        public virtual Task<JToken> PostAsync(object content) => Client.PostJson(Query, content.ToJson());
 
         /// <summary>
         /// Send a POST request with specified json content and returns the json object, deserialized to the specified type
@@ -32,7 +32,7 @@ namespace Netezos.Rpc
         /// <typeparam name="T">Type of the object to deserialize to</typeparam>
         /// <param name="content">Json content to send</param>
         /// <returns></returns>
-        public Task<T> PostAsync<T>(string content) => Client.PostJson<T>(Query, content);
+        public virtual Task<T> PostAsync<T>(string content) => Client.PostJson<T>(Query, content);
 
         /// <summary>
         /// Send a POST request with specified json object content and returns the json object, deserialized to the specified type
@@ -40,7 +40,7 @@ namespace Netezos.Rpc
         /// <typeparam name="T">Type of the object to deserialize to</typeparam>
         /// <param name="content">Object to send</param>
         /// <returns></returns>
-        public Task<T> PostAsync<T>(object content) => Client.PostJson<T>(Query, content.ToJson());
+        public virtual Task<T> PostAsync<T>(object content) => Client.PostJson<T>(Query, content.ToJson());
 
         public override string ToString() => Query;
     }

--- a/Netezos.Rpc/Queries/Post/ForgeOperationsQuery.cs
+++ b/Netezos.Rpc/Queries/Post/ForgeOperationsQuery.cs
@@ -23,8 +23,8 @@ namespace Netezos.Rpc.Queries.Post
                 branch,
                 contents
             });
-        
-        public Task<JToken> PostAsync(string contents)
+
+        public override Task<JToken> PostAsync(string contents)
             => base.PostAsync(contents);
 
         /// <summary>


### PR DESCRIPTION
In ForgeOperationsQuery, `public Task<JToken> PostAsync(string contents)`
is being overridden, but `PostAsync` in RpcPost is not marked as virtual.

This commit assumes that all `PostAsync` methods in RpcPost are allowed
to be overridden even though only one is currently being overridden.

And it marks that one case with `override`.

---

Note that this change was necessary to be able to run tests for #13.